### PR TITLE
Add button component example and tweak templates to support it

### DIFF
--- a/_components/button.md
+++ b/_components/button.md
@@ -1,7 +1,8 @@
 ---
 title: Button
 layout: component
-description: 
+description:
+example: https://codepen.io/hankchizljaw/full/pZYxGy
 keyboard: |
     - <kbd>Enter</kbd> or <kbd>Space</kbd> = Activate Button
 labelling: |

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -3,7 +3,12 @@
       <small>Component Name</small>
       <!-- <h2><a href="{{ item.url }}">{{ item.title }}</a></h2> -->
       <h2>{{ item.title }}</h2>
-      <p>{{ item.description }}</p>
+      {% if item.description %}
+          <p>{{ item.description }}</p>
+      {% endif %}
+      {% if item.example %}
+        <p><a href="{{ item.example }}" rel="external">See an example of this component</a>
+      {% endif %}
     </header>
     
     <div class="keys">

--- a/index.html
+++ b/index.html
@@ -16,7 +16,12 @@ description: A11Y Nutrition Cards is an attempt to digest and simplify the acces
           <small>Component Name</small>
           <h2><a href="{{ item.url | relative_url }}">{{ item.title }}</a></h2>
           <!-- <h2>{{ item.title }}</h2> -->
-          <p>{{ item.description }}</p>
+          {% if item.description %}
+            <p>{{ item.description }}</p>
+          {% endif %}
+          {% if item.example %}
+            <p><a href="{{ item.example }}" rel="external">See an example of this component</a>
+          {% endif %}
         </header>
         
         <div class="keys">


### PR DESCRIPTION
Stuff added:
- I added a new `example` key where we can stick the CodePen links
- I added support for the links by adding a bit of logic to the card headers. It works pretty nice like that, especially if there's a title, a description and an example